### PR TITLE
bin/bp_genbank_ref_extractor: fix typo caught by lintian.

### DIFF
--- a/bin/bp_genbank_ref_extractor
+++ b/bin/bp_genbank_ref_extractor
@@ -60,7 +60,7 @@ See the section bugs for problems when using default values of options.
 
 When retrieving the sequence, a specific assemly can be defined. The value expected
 is a regex that will be case-insensitive. If it matches more than one assembly, it will
-use the first match. It defauls to C<(primary|reference) assembly>.
+use the first match. It defaults to C<(primary|reference) assembly>.
 
 =cut
 my $assembly_regex = '(primary|reference) assembly';


### PR DESCRIPTION
Hi,

Thanks again for your help with the XML parser bug.  While finalizing the upload with the fixed Debian package, I had one lintian issue flagging a minor typo in the pod, so I thought you might like see it fixed.

Have a nice day,  :)
Étienne.